### PR TITLE
Autoadaptive limit

### DIFF
--- a/src/keboola/docker/runtime.clj
+++ b/src/keboola/docker/runtime.clj
@@ -25,8 +25,7 @@
   (apply println strings))
 
 (defn log [what]
-  (println what)
-  )
+  (println what))
 
 (defn log-error-and-exit [what]
   (log-error what)

--- a/src/keboola/facebook/api/request.clj
+++ b/src/keboola/facebook/api/request.clj
@@ -1,7 +1,7 @@
 (ns keboola.facebook.api.request
   (:require   [clojure.spec :as s]
               [keboola.facebook.api.parser :as parser]
-              [keboola.docker.runtime :refer [log-strings app-error]]
+              [keboola.docker.runtime :refer [log-strings app-error log-error]]
               [slingshot.slingshot :refer [try+ throw+]]
               [keboola.http.client :as client]
               [clojure.string :as string]))
@@ -32,7 +32,6 @@
   (re-find #"\d+" (or  (last (re-seq #"limit=\d+" url)) "")))
 
 (defn update-url-with-limit [url new-limit]
-  ;(println "myURL " url new-limit)
   (let [has-query-params (clojure.string/includes? url "?")
         parts (clojure.string/split url #"limit=")
         first-part (apply str (clojure.string/join "limit=" (drop-last parts)))
@@ -67,7 +66,8 @@
              new-url (update-url-with-limit url new-limit)
              new-min-limit-count (if (= new-limit MIN_TRY_LIMIT) (dec min-limit-count)
                                      min-limit-count)]
-         (println "RETYRING" new-min-limit-count new-limit url)
+         (log-error (:body e))
+         (log-error "RETYRING request with limit " new-limit)
          (call-and-adapt api-fn new-url new-min-limit-count))))))
 
 (defn make-get-request

--- a/test/keboola/facebook/api/request_test.clj
+++ b/test/keboola/facebook/api/request_test.clj
@@ -2,7 +2,41 @@
   (:require [keboola.facebook.api.request :as sut]
             [keboola.test-utils.core :refer [test-and-check]]
             [clojure.spec :as s]
-            [clojure.test :as t :refer :all]))
+            [slingshot.slingshot :refer [try+ throw+]]
+            [clojure.test :as t :refer :all])
+  (:use clj-http.fake))
 
 (deftest test-make-url
   (is (test-and-check `sut/make-url 10)))
+
+(def unknown-error-response
+  {:request-time 30136, :repeatable? false, :protocol-version {:name "HTTP", :major 1, :minor 1}, :streaming? true, :chunked? false, :reason-phrase "Internal Server Error", :headers {}, :orig-content-encoding nil, :status 500, :length 77, :body "{\"error\":{\"code\":1,\"message\":\"An unknown error occurred\",\"error_subcode\":99}}", :trace-redirects ["https://graph.facebook.com/v2.8/adsblablabla"]})
+
+(def success-response
+  {:request-time 30, :repeatable? false, :protocol-version {:name "HTTP", :major 1, :minor 1}, :streaming? true, :chunked? false, :headers {}, :orig-content-encoding nil, :status 200, :length 77, :body "{}", :trace-redirects ["https://graph.facebook.com/v2.8/adsblablabla"]}
+  )
+
+(def error-count (atom 0))
+(defn set-error-count [new-count] (reset! error-count new-count))
+(defn dec-error-count [] (set-error-count (dec @error-count)))
+
+(def apimocks
+  {
+   "https://graph.facebook.com/v2.8/always_unknown_error_fail"
+   (fn [req]
+     unknown-error-response)
+   "https://graph.facebook.com/v2.8/fail_on_error_count_and_decrement"
+   (fn [req]
+     (if (= @error-count 0)
+       success-response
+       (do
+         (dec-error-count)
+         unknown-error-response)))
+   })
+
+(deftest make-paging-fn-test
+  (let [call-url-fn (sut/make-paging-fn "")]
+    (with-global-fake-routes-in-isolation
+      apimocks
+      (call-url-fn "https://graph.facebook.com/v2.8/always_unknown_error_fail")
+      )))

--- a/test/keboola/facebook/api/request_test.clj
+++ b/test/keboola/facebook/api/request_test.clj
@@ -37,9 +37,10 @@
          unknown-error-response)))
    })
 
-(deftest make-paging-fn-test
-  (let [call-url-fn (sut/make-paging-fn "")]
+#_(deftest make-paging-fn-test
+  (let [ ]
     (with-global-fake-routes-in-isolation
       apimocks
-      (call-url-fn "https://graph.facebook.com/v2.8/always_unknown_error_fail")
+      (sut/make-get-request "https://graph.facebook.com/v2.8/always_unknown_error_fail")
+      true
       )))

--- a/test/keboola/facebook/api/request_test.clj
+++ b/test/keboola/facebook/api/request_test.clj
@@ -9,6 +9,9 @@
 (deftest test-make-url
   (is (test-and-check `sut/make-url 10)))
 
+(def reduce-data-response
+  {:request-time 21463, :repeatable? false, :protocol-version {:name "HTTP", :major 1, :minor 1}, :streaming? true, :chunked? false, :reason-phrase "Internal Server Error", :headers {}, :orig-content-encoding nil, :status 500, :length 108, :body "{\"error\":{\"code\":1,\"message\":\"Please reduce the amount of data you're asking for, then retry your request\"}}"})
+
 (def unknown-error-response
   {:request-time 30136, :repeatable? false, :protocol-version {:name "HTTP", :major 1, :minor 1}, :streaming? true, :chunked? false, :reason-phrase "Internal Server Error", :headers {}, :orig-content-encoding nil, :status 500, :length 77, :body "{\"error\":{\"code\":1,\"message\":\"An unknown error occurred\",\"error_subcode\":99}}", :trace-redirects ["https://graph.facebook.com/v2.8/adsblablabla"]})
 

--- a/test/keboola/facebook/api/request_test.clj
+++ b/test/keboola/facebook/api/request_test.clj
@@ -9,8 +9,24 @@
 (deftest test-make-url
   (is (test-and-check `sut/make-url 10)))
 
+(deftest test-update-url-with-limit
+  (let [testfn sut/update-url-with-limit
+        stemurl "https://graphapi.com"
+        params "?token=aa&ff=ss"
+        paramswithlimit (str params "&limit=1&ccc=dd" )
+        multilimitparams (str paramswithlimit "&limit=2")]
+    (is (= (testfn stemurl "25") (str stemurl "?limit=25")))
+    (is (= (testfn stemurl 25) (str stemurl "?limit=25")))
+    (is (= (testfn (str stemurl params) "25") (str stemurl params "&limit=25")))
+    (is (= (testfn (str stemurl paramswithlimit) "25") (str stemurl params "&limit=25&ccc=dd")))
+    (is (= (testfn (str stemurl multilimitparams) "25") (str stemurl paramswithlimit "&limit=25")))
+    ))
+
 (def reduce-data-response
   {:request-time 21463, :repeatable? false, :protocol-version {:name "HTTP", :major 1, :minor 1}, :streaming? true, :chunked? false, :reason-phrase "Internal Server Error", :headers {}, :orig-content-encoding nil, :status 500, :length 108, :body "{\"error\":{\"code\":1,\"message\":\"Please reduce the amount of data you're asking for, then retry your request\"}}"})
+
+(def error-400-response
+  {:request-time 21463, :repeatable? false, :protocol-version {:name "HTTP", :major 1, :minor 1}, :streaming? true, :chunked? false, :reason-phrase "Internal Server Error", :headers {}, :orig-content-encoding nil, :status 400, :length 108, :body "{\"error\":{\"code\":1,\"message\":\"There cannot be more than 93 days (8035200 s) between since and until\"}}"})
 
 (def unknown-error-response
   {:request-time 30136, :repeatable? false, :protocol-version {:name "HTTP", :major 1, :minor 1}, :streaming? true, :chunked? false, :reason-phrase "Internal Server Error", :headers {}, :orig-content-encoding nil, :status 500, :length 77, :body "{\"error\":{\"code\":1,\"message\":\"An unknown error occurred\",\"error_subcode\":99}}", :trace-redirects ["https://graph.facebook.com/v2.8/adsblablabla"]})
@@ -23,8 +39,13 @@
 (defn set-error-count [new-count] (reset! error-count new-count))
 (defn dec-error-count [] (set-error-count (dec @error-count)))
 
+
+
 (def apimocks-templates
   {
+   "https://graph.facebook.com/v2.8/always_400?token=aa"
+   (fn [req]
+     error-400-response)
    "https://graph.facebook.com/v2.8/always_200?token=aa"
    (fn [req]
      success-response)
@@ -39,6 +60,14 @@
          (dec-error-count)
          (rand-nth [unknown-error-response reduce-data-response]))))})
 
+
+(deftest test-400-response
+  (with-global-fake-routes-in-isolation
+    apimocks-templates
+    (try+
+      (sut/make-get-request "https://graph.facebook.com/v2.8/always_400?token=aa")
+      (catch Object e
+        (is (= (:status e) 400))))))
 
 (defn generate-apimocks [max-limit]
   (into {} (mapcat


### PR DESCRIPTION
retry on fb api 500 `unknown error` or `reduce data` error.  Reduce limit param by half of its current value, if fb api returns those errors on 3 consecutive requests with limit 1 then fail with error. Also keep the current limit value for next pages requests.

FIXES #12
FIXES #13