### PR TITLE
debug token sync action

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ run-docker:
 # runs extractor a compiled jar file as java app. Built via boot build
 # command or make build-jar command.
 run-jar:
-	java -Xmx1g -jar targetinsights/project.jar -d $(DATADIR)
+	java -Xmx1g -jar targetinsights/exinsights-0.0.1.jar -d $(DATADIR)
 
 # runs extractor directly from boot ie runs as clojure program
 run-boot:

--- a/changelog.md
+++ b/changelog.md
@@ -2,3 +2,5 @@
 	- list accounts
 	- save account-id
 	- various fixes
+### 3.7.0
+	- debug token sync action

--- a/src/keboola/docker/config.clj
+++ b/src/keboola/docker/config.clj
@@ -41,6 +41,15 @@
   (:parameters (apply load-config datadir))
   )
 
+(defn app-access-token [& datadir]
+  (let
+      [auth-info (get-in
+                  (apply load-config datadir)
+                  [:authorization :oauth_api :credentials])
+       app-secret (:#appSecret auth-info)
+       app-id (:appKey auth-info)]
+    (str app-id "|" app-secret)))
+
 (defn user-credentials [& datadir]
   (let
       [data (get-in

--- a/src/keboola/facebook/api/request.clj
+++ b/src/keboola/facebook/api/request.clj
@@ -212,3 +212,8 @@
   (apply concat (get-request access-token "me/adaccounts"
                              :query {:fields "account_id,id,business_name,name,currency"}
                              :version version)))
+
+(defn debug-token [app-token input-token & {:keys [version]}]
+  (let [query {:access_token app-token :input_token input-token}
+        url (make-url "debug_token" version)]
+    (:body (client/GET url :query-params query :as :json))))

--- a/src/keboola/facebook/insights_extractor/core.clj
+++ b/src/keboola/facebook/insights_extractor/core.clj
@@ -60,6 +60,7 @@
       (empty? credentials) (docker-runtime/user-error "Missing facebook credentials")
       (empty? (:token credentials)) (docker-runtime/user-error "Missing facebook token"))
     (case action
+      "debugtoken" (sync-actions/debug-token (docker-config/app-access-token datadir) credentials)
       "accounts" (sync-actions/accounts credentials config)
       "adaccounts" (sync-actions/adaccounts credentials config)
       (treat  #(run credentials parameters (docker-config/out-dir-path datadir))))))

--- a/src/keboola/facebook/insights_extractor/sync_actions.clj
+++ b/src/keboola/facebook/insights_extractor/sync_actions.clj
@@ -15,3 +15,9 @@
   (let [token (:token credentials)
         accounts (request/get-adaccounts token)]
     (log (generate-string accounts))))
+
+(defn debug-token [app-token credentials]
+  (let [input-token (:token credentials)
+        response-data (:data (request/debug-token app-token input-token))
+        result (dissoc response-data :app_id)]
+      (log (generate-string result))))


### PR DESCRIPTION
FIXES #15 
provide sync action `debugtoken` that implments https://developers.facebook.com/docs/graph-api/reference/v2.9/debug_token and returns info about authorized token e.g:

```
{"application":"Keboola Test","expires_at":1498626000,"is_valid":true,"scopes":["user_friends","manage_pages","pages_show_list","ads_management","business_management","public_profile"],"user_id":"128854997588309"}
```