### PR TITLE
:zap: handle and propagate sync actions errors

### DIFF
--- a/src/keboola/facebook/insights_extractor/sync_actions.clj
+++ b/src/keboola/facebook/insights_extractor/sync_actions.clj
@@ -8,17 +8,24 @@
 (defn disable-log-token [] (reset! log-token? false))
 
 (defn accounts [credentials config]
-  (let [token (:token credentials)
-        version (-> config :parameters :api-version)
-        accounts (mapv #(dissoc % :access_token) (request/get-accounts token :version version))]
-    (log (generate-string accounts))))
+  (try+
+   (let [token (:token credentials)
+         version (-> config :parameters :api-version)
+         accounts (mapv #(dissoc % :access_token) (request/get-accounts token :version version))]
+     (log (generate-string accounts)))
+   (catch Object e
+     (log (generate-string {:code (:status e 500) :error (:body e)})))))
 
 
 (defn adaccounts [credentials config]
-  (let [token (:token credentials)
-        version (-> config :parameters :api-version)
-        accounts (request/get-adaccounts token :version version)]
-    (log (generate-string accounts))))
+  (try+
+   (let [token (:token credentials)
+         version (-> config :parameters :api-version)
+         accounts (request/get-adaccounts token :version version)]
+     (log (generate-string accounts)))
+   (catch Object e
+     (log (generate-string {:code (:status e 500) :error (:body e)}))))
+  )
 
 (defn log-debug-token [app-token credentials prepend-message]
   (try+


### PR DESCRIPTION
FIXES #7 
FIXES #20 
Applies to adaccounts and accounts sync actions
if error occurs then returned json string contains `{code: number, error: error_object}` object.

