### PR TITLE
sync action igaccounts to return instagram linked accounts

### DIFF
--- a/src/keboola/facebook/api/request.clj
+++ b/src/keboola/facebook/api/request.clj
@@ -208,6 +208,11 @@
 (defn get-accounts [access-token & {:keys [version]}]
   (apply concat (get-request access-token "me/accounts" :version version)))
 
+(defn get-igaccounts [access-token & {:keys [version]}]
+  (apply concat (get-request access-token "me/accounts"
+                             :query {:fields "instagram_business_account,name,category"}
+                             :version version)))
+
 (defn get-adaccounts [access-token & {:keys [version]}]
   (apply concat (get-request access-token "me/adaccounts"
                              :query {:fields "account_id,id,business_name,name,currency"}

--- a/src/keboola/facebook/extractor/core.clj
+++ b/src/keboola/facebook/extractor/core.clj
@@ -69,6 +69,7 @@
       "debugtoken" (sync-actions/log-debug-token app-access-token credentials nil)
       "accounts" (sync-actions/accounts credentials config)
       "adaccounts" (sync-actions/adaccounts credentials config)
+      "igaccounts" (sync-actions/igaccounts credentials config)
       (treat  #(run credentials parameters out-dir-path app-access-token)))))
 
 (defn -main [& args]

--- a/src/keboola/facebook/extractor/sync_actions.clj
+++ b/src/keboola/facebook/extractor/sync_actions.clj
@@ -27,6 +27,19 @@
      (log (generate-string {:code (:status e 500) :error (:body e)}))))
   )
 
+(defn igaccounts [credentials config]
+  (try+
+   (let [token (:token credentials)
+         version (-> config :parameters :api-version)
+         accounts (request/get-igaccounts token :version version)
+         ig-accounts (filter #(contains? % :instagram_business_account) accounts)
+         result (map #(assoc (select-keys % [:name :category]) :id (-> % :instagram_business_account :id) :fb_page_id (:id %)) ig-accounts)]
+     (log (generate-string result)))
+   (catch Object e
+     (log (generate-string {:code (:status e 500) :error (:body e)}))))
+  )
+
+
 (defn log-debug-token [app-token credentials prepend-message]
   (try+
    (if @log-token?


### PR DESCRIPTION
FIXES #29 
related to #19 

Sync akcia **`igaccounts`** ktora vrati zoznam fb pages ktore maju nalinkovany instagram bussiness acccount, id instagram bussines accountu je pod property id.
priklad vystupu:

```
[{"name":"Noonania","category":"Community","id":"17841401382855558","fb_page_id":"1960059394258217"}]
```


