### PR TITLE
Fix media posted before recoverable error

### DIFF
--- a/src/keboola/facebook/api/parser.clj
+++ b/src/keboola/facebook/api/parser.clj
@@ -106,6 +106,7 @@
         (mapcat #(flatten-array-value (:value %) (:end_time %)) array)
         (some? (ads-action-stats-types array-name))
         (map #(assoc % :ads_action_name (name array-name)) array)
+        (and (= array-name :media) (empty? array)) '()
         :else (app-error (str "unsuported array:" array-name array))))
 
 (s/fdef filter-scalars

--- a/test/keboola/facebook/extractor/query_test.clj
+++ b/test/keboola/facebook/extractor/query_test.clj
@@ -1,6 +1,18 @@
 (ns keboola.facebook.extractor.query-test
   (:require [keboola.facebook.extractor.query :as sut]
-            [clojure.test :refer :all]))
+            [keboola.test-utils.core :as test-utils]
+            [clojure.java.io :as io]
+            [keboola.facebook.api.request-test :refer [media-posted-before-error-response]]
+            [clojure.test :refer :all])
+  (:use clj-http.fake))
+
+(def ^:dynamic *tmpdir* "")
+
+(defn setup-tmpdir [f]
+  (binding [*tmpdir* (test-utils/mk-tmp-dir! "exfbtestquery")]
+    (f)
+    (test-utils/recursive-delete *tmpdir*)))
+
 
 (deftest test-query-contains-insights?
   (is (not (sut/query-contains-insights? {})))
@@ -20,3 +32,25 @@
   (is (not (sut/query-path-feed? {:path "ratings" :fields "feed"})))
   (is (sut/query-path-feed? {:path "feed" :fields "insights"}))
   (is (sut/query-path-feed? {:path "me/feed" :fields "insights"})))
+
+
+(defn empty-dir? [path]
+  (let [file (io/file path)]
+    (assert (.exists file))
+    (assert (.isDirectory file))
+    (-> file .list empty?)))
+
+(deftest test-media-posted-before-error-response-query
+  (let [query {:name "mediatest" :version "v2.11" :query {:path "media" :ids "123" :fields "fields" :since "now" :until "now"}}
+        token "token"
+        out-dir *tmpdir*]
+    (println *tmpdir*)
+    (with-global-fake-routes-in-isolation
+      {
+       "https://graph.facebook.com/v2.11/media?path=media&ids=123&fields=fields&since=now&until=now&access_token=token"
+       (fn [req]
+         media-posted-before-error-response)}
+      (sut/run-nested-query token out-dir query)
+      (is (empty-dir? *tmpdir*)))))
+
+(use-fixtures :once setup-tmpdir)


### PR DESCRIPTION
FIXES #35 
related to #19 

problem
if recoverable error(media posted before) was hit after first api request(not paginated request) then it failed on internal error(unparsable structure)

solution
Make unparsable structure parsable as data response.