### PR TITLE
v3.19

### DIFF
--- a/src/keboola/facebook/api/request.clj
+++ b/src/keboola/facebook/api/request.clj
@@ -7,7 +7,7 @@
               [clojure.string :as string]))
 
 (def graph-api-url "https://graph.facebook.com/")
-(def default-version "v2.8")
+(def default-version "v2.12")
 
 (s/fdef make-url
         :args (s/or :path-only (s/cat :path string?)

--- a/src/keboola/facebook/extractor/query.clj
+++ b/src/keboola/facebook/extractor/query.clj
@@ -67,13 +67,17 @@
       (string/includes? (or path "") "insights")))
 
 (defn query-path-feed? [{:keys [path] :or {path ""}}]
-  (string/includes? (or path "") "feed")
-  )
+  (string/includes? (or path "") "feed"))
+
+(defn query-need-userinfo? [{:keys [fields path] :or {fields "" path ""}}]
+  (or (some #(string/includes? (or fields "") %) ["likes" "from" "username"])
+      (string/includes? (or path "") "likes")))
 
 (defn need-page-token? [query]
   (and (runtime/keboola-ex-facebook-component?)
        (or (query-contains-insights? query)
-           (not (query-path-feed? query)))))
+           (not (query-path-feed? query))
+           (query-need-userinfo? query))))
 
 (defn run-query [query all-ids credentials out-dir]
   (runtime/log-strings "Run query:" query)

--- a/test/keboola/facebook/extractor/query_test.clj
+++ b/test/keboola/facebook/extractor/query_test.clj
@@ -33,6 +33,13 @@
   (is (sut/query-path-feed? {:path "feed" :fields "insights"}))
   (is (sut/query-path-feed? {:path "me/feed" :fields "insights"})))
 
+(deftest test-query-need-userinfo?
+  (is (not (sut/query-need-userinfo? {})))
+  (is (not (sut/query-need-userinfo? {:path "ratings" :fields "feed"})))
+  (is (sut/query-need-userinfo? {:path "likes" :fields "insights"}))
+  (is (sut/query-need-userinfo? {:path "" :fields "likes"}))
+  (is (sut/query-need-userinfo? {:path "me/feed" :fields "from"})))
+
 
 (defn empty-dir? [path]
   (let [file (io/file path)]


### PR DESCRIPTION
FIXES #42 
FIXES #41 

- use page acces token when extracting user info objects such as likes, comments{from
- set default fb api version to v2.12