### PR TITLE
table columns provisioning via state

### DIFF
--- a/src/keboola/docker/state.clj
+++ b/src/keboola/docker/state.clj
@@ -1,0 +1,34 @@
+(ns keboola.docker.state
+  (:require [cheshire.core :refer [generate-string parse-string]]
+            [clojure.string :refer [trim]]
+            [keboola.docker.state-protocol :as protocol]
+            [keboola.docker.config :refer [default-dir check-path]]))
+
+(defrecord NoopState []
+  protocol/IState
+  (load [this content-path] {})
+  (save [this content content-path] nil))
+
+(defrecord JsonFileState [dir-path root-content-path]
+   protocol/IState
+  (load [this content-path]
+    (let [path (str (check-path  (:dir-path this)) "in/state.json")
+          file-exists (.exists (java.io.File. path))
+          file-content (if file-exists (slurp path) "{}")
+          state-path (concat (:root-content-path this) content-path)
+          parsed-state (parse-string file-content true)]
+      (get-in parsed-state state-path)))
+  (save [this content content-path]
+    (let [path (str (check-path  (:dir-path this)) "out/state.json")
+          file-exists (.exists (java.io.File. path))
+          file-content (if file-exists (slurp path) "{}")
+          state-path (concat (:root-content-path this) content-path)
+          parsed-state (parse-string file-content true)
+          updated-content (assoc-in parsed-state state-path content)]
+      (spit path (generate-string updated-content)))))
+
+(defn make-json-state-file
+  ([use-state? root-content-path dir-path]
+   (if use-state?
+     (JsonFileState. dir-path root-content-path)
+     (NoopState.))))

--- a/src/keboola/docker/state_protocol.clj
+++ b/src/keboola/docker/state_protocol.clj
@@ -1,0 +1,5 @@
+(ns keboola.docker.state-protocol)
+
+(defprotocol IState
+  (load [this content-path])
+  (save [this content content-path]))

--- a/test/keboola/facebook/extractor/query_test.clj
+++ b/test/keboola/facebook/extractor/query_test.clj
@@ -3,6 +3,7 @@
             [keboola.test-utils.core :as test-utils]
             [clojure.java.io :as io]
             [keboola.facebook.api.request-test :refer [media-posted-before-error-response]]
+            [keboola.docker.state :refer [make-json-state-file]]
             [clojure.test :refer :all])
   (:use clj-http.fake))
 
@@ -49,6 +50,7 @@
 
 (deftest test-media-posted-before-error-response-query
   (let [query {:name "mediatest" :version "v2.11" :query {:path "media" :ids "123" :fields "fields" :since "now" :until "now"}}
+        state (make-json-state-file false [] *tmpdir*)
         token "token"
         out-dir *tmpdir*]
     (println *tmpdir*)
@@ -57,7 +59,7 @@
        "https://graph.facebook.com/v2.11/media?path=media&ids=123&fields=fields&since=now&until=now&access_token=token"
        (fn [req]
          media-posted-before-error-response)}
-      (sut/run-nested-query token out-dir query)
+      (sut/run-nested-query token out-dir query state)
       (is (empty-dir? *tmpdir*)))))
 
 (use-fixtures :once setup-tmpdir)


### PR DESCRIPTION
fixes #8

- use state to save table columns after each query run
- load saved columns from state and merge them with actual columns from the current query run if query has `merge-state-columns: true` in config.json


