### PR TITLE
dont halt on sigterm and wait for sigkill

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,4 +8,4 @@ ADD . /code
 WORKDIR /code
 RUN boot build
 RUN chmod a+r target/ex-fb-graph-api-1.0.jar
-CMD ["java", "-jar", "-Xmx1g","target/ex-fb-graph-api-1.0.jar", "-d" , "/data/"]
+CMD ["java", "-jar", "-Xmx1g", "-Xrs", "target/ex-fb-graph-api-1.0.jar", "-d", "/data/"]


### PR DESCRIPTION
fixes #46 
Nenasiel som uplne idealny sposob ako odignorovat sigterm tak aby apka spadla az na sigkill. Z toho co java ponuka tam je `AddShutdownHook`(https://docs.oracle.com/javase/7/docs/api/java/lang/Runtime.html#addShutdownHook), ten iba vykona kod ale nezamedzi naslednemu ukonceniu(nepocka na sigkill). 

Skusal som rozne kombinovat entrypoint/cmd dockerfilu ale tiez bez vysledku. 
V `Dockerfile` je:
**`CMD ["java", "-jar", "-Xmx1g", "target/ex-fb-graph-api-1.0.jar", "-d", "/data/"]`**
ten urobi to ze pusti `java` ako init process s PID 1 co ma udajne za nasledok ignorovanie SIGTERMU:
```
For PID 1, though, the kernel won’t fall back to any default behavior when forwarding TERM. If your process hasn’t registered its own handlers (which most processes don’t), TERM will have no effect on the process.
```
(https://engineeringblog.yelp.com/2016/01/dumb-init-an-init-for-docker.html)
^^To by vysvetlovalo preco to na SIGTERM nepada u inych kbc komponent ktore to maju rovnako(CMD + run.php v exec form) ale nechapem preco to nefunguje tak aj tu.

Jedine co nakoniec zabralo bolo uprava java proces options pridanim `-Xrs` co ma za nasledok to ze JVM prestava handlovat niektore signaly vratane SIGTERM, viac infa tu:
https://www.ibm.com/support/knowledgecenter/en/SSYKE2_8.0.0/com.ibm.java.vm.80.doc/docs/j9_signals_j9_handling.html
Zabralo znamena za mi lokalne beziaci docker run na zavolanie `docker stop <containerId>` nespadne hned, pocka 10 sekund a potom zahlasi `error 137` (128+9 == SIGKILL)
Tiez som pustal takto zbuildovany image(s tagom test) v kbc a skusal ho terminovat a preslo teda job terminovalo.

