### PR TITLE
Revert "Revert "update to clojure 1.10 + deps""

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,8 @@
-FROM clojure:boot-2.8.1-alpine
+FROM clojure:boot-2.8.2-alpine
 MAINTAINER <tomas.kacur@keboola.com>
 
 # ENV BOOT_JVM_OPTIONS=-Xmx256m
-ENV BOOT_CLOJURE_VERSION=1.9.0
+ENV BOOT_CLOJURE_VERSION=1.10.0
 
 ADD . /code
 WORKDIR /code

--- a/build.boot
+++ b/build.boot
@@ -2,20 +2,20 @@
 (set-env!
  :source-paths #{"src" "test"}
  :dependencies '[
-                 [org.clojure/clojure "1.9.0"]
-                 [cheshire "5.8.0"]
-                 [clj-http "3.7.0"]
-                 [clojure-csv/clojure-csv "2.0.2"]
+                 [org.clojure/clojure "1.10.0"]
+                 [cheshire "5.8.1"]
+                 [clj-http "3.9.1"]
                  [de.ubercode.clostache/clostache "1.4.0"]
-                 [org.clojure/tools.cli "0.3.5"]
+                 [org.clojure/tools.cli "0.4.1"]
                  [semantic-csv "0.2.0"]
                  [org.clojure/data.csv "0.1.4"]
                  [org.clojure/test.check "0.9.0"]
-                 [org.clojure/core.async "0.4.474"]
+                 [org.clojure/core.async "0.4.490"]
                  [adzerk/boot-test "1.2.0" :scope "test"]
                  [clj-http-fake "1.0.3"]
                  [slingshot "0.12.2"]
-                 [clj-time "0.14.2"]])
+                 [clj-time "0.15.1"]
+                 [clojure-csv/clojure-csv "2.0.2"]])
 
 
 (require '[adzerk.boot-test :refer :all])

--- a/src/keboola/facebook/extractor/sync_actions.clj
+++ b/src/keboola/facebook/extractor/sync_actions.clj
@@ -49,4 +49,4 @@
            result (dissoc response-data :app_id)]
        (log (str prepend-message (generate-string result)))))
    (catch Object e
-     (log (generate-string {:message "Failed to log token info" :error e})))))
+     (log (generate-string {:message "Failed to log token info" :error (:body e)})))))


### PR DESCRIPTION
fixes #62 
Reverts keboola/ex-facebook-graph-api#63

error happened when trying to log the whole response of the failed http request that included object that was unknwon to JSON decode function(org.apache.http.impl.client.InternalHttpClient). The fix is to log only body of the resopnse.

