### PR TITLE
double analyzed sample rows count to 12K

### DIFF
--- a/src/keboola/facebook/extractor/output.clj
+++ b/src/keboola/facebook/extractor/output.clj
@@ -10,7 +10,7 @@
             [clojure.java.io :as io]))
 
 (def chan-buffer-size 300)
-(def sample-rows-count 6000)
+(def sample-rows-count 12000)
 
 (defn delete-file-if-empty [file-path]
   (if (= 0 (.length (io/file file-path)))


### PR DESCRIPTION
increase lookaside buffer to 12000 to mitigate issues with non analyzed parsed data rows(see #69 resp #56)