### PR TITLE
set default facebok api version to v3.2

### DIFF
--- a/src/keboola/facebook/api/request.clj
+++ b/src/keboola/facebook/api/request.clj
@@ -7,7 +7,7 @@
               [clojure.string :as string]))
 
 (def graph-api-url "https://graph.facebook.com/")
-(def default-version "v2.12")
+(def default-version "v3.2")
 
 (s/fdef make-url
         :args (s/or :path-only (s/cat :path string?)


### PR DESCRIPTION
jedna sa o fallback verzi ktora sa pouzije ak sa v configu ziadna nenastavi. UI uz nejaku dobu automaticky uklada prazdnu verzi na v3.1 takze takyto fallback sa uz vobec nepouziva a je bezpecne to dvihnut.
https://keboola.slack.com/archives/C036XEZA4/p1553505848039500