### PR TITLE
support outbound_clicks ads insights extraction

### DIFF
--- a/src/keboola/facebook/api/parser.clj
+++ b/src/keboola/facebook/api/parser.clj
@@ -94,7 +94,7 @@
                               :video_avg_time_watched_actions :video_complete_watched_actions
                               :video_p100_watched_actions :video_p25_watched_actions
                               :video_p50_watched_actions :video_p75_watched_actions
-                              :video_p95_watched_actions :website_ctr :website_purchase_roas})
+                              :video_p95_watched_actions :website_ctr :website_purchase_roas :outbound_clicks})
 #_(s/fdef flatten-array
         :args (s/cat :array (s/coll-of ::ds/insights) :array-name (s/or :val :values))
         :ret (s/* (s/map-of keyword? ::ds/table-value)))


### PR DESCRIPTION
fixes https://github.com/keboola/ex-facebook-graph-api/issues/68
outbound_clicks je tzv adactionstats object
https://developers.facebook.com/docs/marketing-api/reference/ads-action-stats/
Extraktor takyto objekt vie extrahovat akurat mu treba povedat ktore property..Tato uprava jednoducho prirazduje outbound_clicks ako adactionstats object.