### PR TITLE
fb ads: parse conversions as list of ads action stats

### DIFF
--- a/src/keboola/facebook/api/parser.clj
+++ b/src/keboola/facebook/api/parser.clj
@@ -94,7 +94,7 @@
                               :video_avg_time_watched_actions :video_complete_watched_actions
                               :video_p100_watched_actions :video_p25_watched_actions
                               :video_p50_watched_actions :video_p75_watched_actions
-                              :video_p95_watched_actions :website_ctr :website_purchase_roas :outbound_clicks})
+                              :video_p95_watched_actions :website_ctr :website_purchase_roas :outbound_clicks :conversions})
 #_(s/fdef flatten-array
         :args (s/cat :array (s/coll-of ::ds/insights) :array-name (s/or :val :values))
         :ret (s/* (s/map-of keyword? ::ds/table-value)))


### PR DESCRIPTION
fixes #75 
podla docs su `conversions` typu `list<AdsActionStats>`
https://developers.facebook.com/docs/marketing-api/reference/adgroup/insights/
Extractor takuto strukturu vie parsovat akurat mu to treba explicitne "povedat" tj ze property conversions je ads action stats array.