### PR TITLE
ex fb ads fix adsets extraction

### DIFF
--- a/src/keboola/facebook/extractor/output.clj
+++ b/src/keboola/facebook/extractor/output.clj
@@ -32,7 +32,12 @@
    "ratings" ["reviewer_id"]})
 
 (def ENDPOINT-SPECIFIC-PK-MAP
-  {"" ["ad_id"]})
+  {"" ["ad_id" "adset_id"]})
+(def SUBSTITUTE-PK-MAP
+  {"adset_id" "ad_id"})
+
+(defn table-has-column? [table-columns column]
+  (some #(= % (keyword column)) table-columns))
 
 (defn get-primary-key [table-columns table-name context]
   (let [endpoint (:path context)
@@ -43,7 +48,9 @@
         extended-pk (concat all-tables-pk table-only-pk endpoint-only-pk)]
     (concat basic-pk
             (filter
-             (fn [column] (some #(= % (keyword column)) table-columns))
+             (fn [column]
+               (and (table-has-column? table-columns column)
+                    (not (table-has-column? table-columns (get SUBSTITUTE-PK-MAP column "")))))
              extended-pk))))
 
 (defn get-table-name [row]

--- a/test/keboola/facebook/extractor/output_test.clj
+++ b/test/keboola/facebook/extractor/output_test.clj
@@ -19,5 +19,7 @@
   (test-pk (sut/get-primary-key [:id :key1 :foo :key2] "" {}) ["id" "key1" "key2"])
   (test-pk (sut/get-primary-key [:id :key1 :foo :key2] "" {:path ""}) ["id" "key1" "key2"])
   (test-pk (sut/get-primary-key [:id :key1 :foo :key2 :ad_id] "" {:path ""}) ["id" "key1" "key2" "ad_id"])
+  (test-pk (sut/get-primary-key [:id :key1 :foo :key2 :ad_id :adset_id] "" {:path ""}) ["id" "key1" "key2" "ad_id"])
+  (test-pk (sut/get-primary-key [:id :key1 :foo :key2 :adset_id] "" {:path ""}) ["id" "key1" "key2" "adset_id"])
   (test-pk (sut/get-primary-key [:id :key1 :foo :key2 :ad_id] "" {:path "ads"}) ["id" "key1" "key2"])
   (test-pk (sut/get-primary-key [:id :key1 :foo :key2 :reviewer_id] "ratings" {}) ["id" "key1" "key2" "reviewer_id"]))


### PR DESCRIPTION
add `adset_id` column to pk of OM manifest if endpoint is empty and there is no ad_id column to present to prevent breaking change with existing configurations.
fixes https://keboola.atlassian.net/browse/COM-42