### PR TITLE
set default fb api version to 5.0

### DIFF
--- a/src/keboola/facebook/api/request.clj
+++ b/src/keboola/facebook/api/request.clj
@@ -7,7 +7,7 @@
               [clojure.string :as string]))
 
 (def graph-api-url "https://graph.facebook.com/")
-(def default-version "v3.2")
+(def default-version "v5.0")
 
 (s/fdef make-url
         :args (s/or :path-only (s/cat :path string?)


### PR DESCRIPTION
related to https://github.com/keboola/kbc-ui/pull/4455
Set default facebook api version to 5.0 that is used when not specified in config