### PR TITLE
support and video_play_actions video_thruplay_watched_actions 

### DIFF
--- a/src/keboola/facebook/api/parser.clj
+++ b/src/keboola/facebook/api/parser.clj
@@ -94,7 +94,7 @@
                               :video_avg_time_watched_actions :video_complete_watched_actions
                               :video_p100_watched_actions :video_p25_watched_actions
                               :video_p50_watched_actions :video_p75_watched_actions
-                              :video_p95_watched_actions :website_ctr :website_purchase_roas :outbound_clicks :conversions})
+                              :video_p95_watched_actions :website_ctr :website_purchase_roas :outbound_clicks :conversions :video_play_actions :video_thruplay_watched_actions})
 #_(s/fdef flatten-array
         :args (s/cat :array (s/coll-of ::ds/insights) :array-name (s/or :val :values))
         :ret (s/* (s/map-of keyword? ::ds/table-value)))


### PR DESCRIPTION
https://keboola.atlassian.net/browse/COM-289

Tato uprava "fixuje hlasku" `unsuported array::video_thruplay_watched` a `unsuported array::video_play_actions`. Tu hlasku generuje samotny extraktor kde vlastne hovori ze nevie ako ma parsovat property video_thruplay_watched resp. video_play_actions pretoze vidi ze obsahuju array a nie scalar alebo object. 
Fix spociva v tom ze sa mu povie aby to ju parsoval ako tzv ads action stats type co je nejaka komplexnejsia metriky pre fb ads.
To ci dana property je ads action stats alebo sa da zistit z docs:
vid pre `video_thruplay_watched_actions` https://developers.facebook.com/docs/marketing-api/reference/ad-report-run/insights/ 
![image](https://user-images.githubusercontent.com/1412120/95770531-d5c6f100-0cb9-11eb-83e6-817190fa43c6.png)
vid pre `video_play_actions` https://developers.facebook.com/docs/marketing-api/reference/ads-insights/
![image](https://user-images.githubusercontent.com/1412120/95770638-0149db80-0cba-11eb-864f-ab43a5cc42c2.png)

Konkretne uprava kodu spociva v pridani tychto properties do zoznamu `ads-action-stats-types` aka known ads action stats types. Staci tam pridat samotnu property prefixovanu s dvojbodkou(tzv clojure keyword) tj `:video_play_actions` a `:video_thruplay_watched_actions`

Potom staci pust PR build na travisu a pokial su zelene testy tak by to malo byt cajk vid:
https://travis-ci.org/github/keboola/ex-facebook-graph-api/builds/735066842


