### PR TITLE
use page access token for feed extraction

### DIFF
--- a/src/keboola/facebook/extractor/query.clj
+++ b/src/keboola/facebook/extractor/query.clj
@@ -76,7 +76,7 @@
 (defn need-page-token? [query]
   (and (runtime/keboola-ex-facebook-component?)
        (or (query-contains-insights? query)
-           (not (query-path-feed? query))
+           (query-path-feed? query)
            (query-need-userinfo? query))))
 
 (defn run-query [query all-ids credentials out-dir]


### PR DESCRIPTION
https://keboola.slack.com/archives/CQ1ASK06M/p1614961204003000
Pre stahovanie feed endpointu sa pouziva page access token. 
Testy presli a lokalni mi to fungovalo tiez
![image](https://user-images.githubusercontent.com/1412120/110321295-c69e6200-8011-11eb-8bb1-f3535b6cf334.png)
