### PR TITLE
use more general error for query retry mechanism

### DIFF
--- a/src/keboola/facebook/api/request.clj
+++ b/src/keboola/facebook/api/request.clj
@@ -57,7 +57,7 @@
          (<= 500 status 600)
          (or
           (re-find #"Sorry, something went wrong" (:body e))
-          (re-find #"An unknown error occurred" (:body e))
+          (re-find #"An unknown error" (:body e))
           (re-find #"An unexpected error has occurred. Please retry" (:body e))
           (re-find #"Please reduce the amount of data" (:body e))))
         (and (<= 400 status 600)


### PR DESCRIPTION
https://keboola.slack.com/archives/C1B7SH7T2/p1616666268007600?thread_ts=1616662016.001700&cid=C1B7SH7T2
vsimol som si ze pozmenili hlasku pre "unknwon error" a tak extractor neurobi retry, tak som ju dal viac obecnu aby to zachytil aj novu hlasku.
![image](https://user-images.githubusercontent.com/1412120/112454862-69b4e280-8d59-11eb-97f3-349a3f6ecf0f.png)
