### PR TITLE
allow parse conversion_values as ads actions stats

### DIFF
--- a/src/keboola/facebook/api/parser.clj
+++ b/src/keboola/facebook/api/parser.clj
@@ -83,7 +83,7 @@
      (map? item) (mapcat (fn [[key1 val]] (flatten-value-object (name key1) val)) item)
      :else (list {:key1 "" :key2 "" :value item}))))
 
-(def ads-action-stats-types #{:actions :properties
+(def ads-action-stats-types #{:actions :properties :conversion_values
                               :action_values :canvas_component_avg_pct_view
                               :cost_per_10_sec_video_view :cost_per_action_type :cost_per_unique_action_type
                               :unique_actions :video_10_sec_watched_actions :video_15_sec_watched_actions


### PR DESCRIPTION
vzislo zo zendesku https://keboola.slack.com/archives/CQ1ASK06M/p1647974230982759
Podla [docs](https://developers.facebook.com/docs/marketing-api/reference/ads-insights/) je `conversion_values` typu `list<AdsActionStats>` a tento typ extractor vie parsovat, staci ten mapping pridat do pomocnej struktury (ads-action-stats-types).

testy presli vid https://github.com/keboola/ex-facebook-graph-api/runs/5677635503?check_suite_focus=true