### PR TITLE
fix app error handling

### DIFF
--- a/src/keboola/facebook/extractor/core.clj
+++ b/src/keboola/facebook/extractor/core.clj
@@ -31,8 +31,10 @@
        (if (.contains msg "User request limit reached")
          (log-error-and-exit (str "REQUEST LIMIT REACHED. Up to now extracted data will be uploaded to storage." msg))
          (user-error (str "Facebook api error:" msg)))))
+   (catch Throwable e
+     (app-error (str "unexpected error:" (with-out-str (clojure.stacktrace/print-stack-trace e)))))
    (catch Object e
-     (app-error (str "unexpected error:" (with-out-str (clojure.stacktrace/print-stack-trace e)))))))
+     (app-error (str "unexpected error:" (str e))))))
 
 (defn make-accounts-csv [parameters out-dir]
   (let [filepath (str out-dir "accounts")

--- a/test/keboola/facebook/extractor/core_test.clj
+++ b/test/keboola/facebook/extractor/core_test.clj
@@ -1,0 +1,9 @@
+(ns keboola.facebook.extractor.core-test
+  (:require [keboola.facebook.extractor.core :as sut]
+            [clojure.test :refer :all]
+            [slingshot.slingshot :refer [throw+]]))
+(deftest test-treat-exception
+  (with-redefs [keboola.docker.runtime/app-error (fn [_] "app error")]
+    (is (= "app error" (sut/treat #(throw "aaa"))))
+    (is (= "app error" (sut/treat #(throw+ "aaa"))))
+    (is (= "app error" (sut/treat #(throw+ {:a "aaa"}))))))


### PR DESCRIPTION
related to https://keboola.atlassian.net/browse/COM-1444
Tato uprava fixuje spracovanie vynimiek ktore sa vyhodia pri app erroroch. Konkretne doteraz nejak nefungovalo zachytenie vynimiek typu string, musel to byt throwable object.