### PR TITLE
use page access token to retrieve posts or published_posts

### DIFF
--- a/src/keboola/facebook/extractor/query.clj
+++ b/src/keboola/facebook/extractor/query.clj
@@ -69,9 +69,11 @@
 (defn query-path-feed? [{:keys [path] :or {path ""}}]
   (string/includes? (or path "") "feed"))
 
+(defn query-path-posts? [{:keys [path] :or {path ""}}]
+  (string/includes? (or path "") "posts"))
+
 (defn query-path-ratings? [{:keys [path] :or {path ""}}]
   (string/includes? (or path "") "ratings"))
-
 
 (defn query-need-userinfo? [{:keys [fields path] :or {fields "" path ""}}]
   (or (some #(string/includes? (or fields "") %) ["likes" "from" "username"])

--- a/src/keboola/facebook/extractor/query.clj
+++ b/src/keboola/facebook/extractor/query.clj
@@ -84,6 +84,7 @@
        (or (query-contains-insights? query)
            (query-path-ratings? query)
            (query-path-feed? query)
+           (query-path-posts? query)
            (query-need-userinfo? query))))
 
 (defn run-async-insights-query [token out-dir name query version]

--- a/test/keboola/facebook/extractor/query_test.clj
+++ b/test/keboola/facebook/extractor/query_test.clj
@@ -13,7 +13,6 @@
     (f)
     (test-utils/recursive-delete *tmpdir*)))
 
-
 (deftest test-query-contains-insights?
   (is (not (sut/query-contains-insights? {})))
   (is (not (sut/query-contains-insights? {:fields "asasd"})))
@@ -33,13 +32,21 @@
   (is (sut/query-path-feed? {:path "feed" :fields "insights"}))
   (is (sut/query-path-feed? {:path "me/feed" :fields "insights"})))
 
+(deftest test-query-path-posts?
+  (is (not (sut/query-path-posts? {})))
+  (is (not (sut/query-path-posts? {:path "ratings" :fields "feed"})))
+  (is (not (sut/query-path-posts? {:path "feed" :fields "insights"})))
+  (is (sut/query-path-posts? {:path "posts" :fields "insights"}))
+  (is (sut/query-path-posts? {:path "me/posts" :fields "insights"}))
+  (is (sut/query-path-posts? {:path "me/published_posts" :fields "insights"}))
+  (is (sut/query-path-posts? {:path "published_posts" :fields "insights"})))
+
 (deftest test-query-need-userinfo?
   (is (not (sut/query-need-userinfo? {})))
   (is (not (sut/query-need-userinfo? {:path "ratings" :fields "feed"})))
   (is (sut/query-need-userinfo? {:path "likes" :fields "insights"}))
   (is (sut/query-need-userinfo? {:path "" :fields "likes"}))
   (is (sut/query-need-userinfo? {:path "me/feed" :fields "from"})))
-
 
 (defn empty-dir? [path]
   (let [file (io/file path)]
@@ -53,8 +60,7 @@
         out-dir *tmpdir*]
     (println *tmpdir*)
     (with-global-fake-routes-in-isolation
-      {
-       "https://graph.facebook.com/v2.11/media?path=media&ids=123&fields=fields&since=now&until=now&access_token=token"
+      {"https://graph.facebook.com/v2.11/media?path=media&ids=123&fields=fields&since=now&until=now&access_token=token"
        (fn [req]
          media-posted-before-error-response)}
       (sut/run-nested-query token out-dir query)


### PR DESCRIPTION
prislo zo zendesku https://keboola.slack.com/archives/CQ1ASK06M/p1661156804921219
Tato uprava zariadi aby pre stahovanie `posts` alebo published_posts` sa pouzil page access token namiesto user access tokenu. Po prepnuti fb stranky na tzv [new pages experience](https://developers.facebook.com/docs/pages/new-pages-experience) to pre user access tokeny prestalo fungovat
