### PR TITLE
try to retrieve page token from page details via user token

### DIFF
--- a/src/keboola/facebook/api/request.clj
+++ b/src/keboola/facebook/api/request.clj
@@ -279,3 +279,10 @@
   (let [query {:access_token app-token :input_token input-token}
         url (make-url "debug_token" version)]
     (:body (client/GET url :query-params query :as :json))))
+
+; https://developers.facebook.com/docs/pages/access-tokens
+; https://graph.facebook.com/PAGE-ID?fields=access_token&access_token=USER-ACCESS-TOKEN
+(defn get-page-token-via-page-details [access-token page-id & {:keys [version]}]
+  (:access_token (apply concat (get-request access-token page-id
+                                            :query {:fields "access_token"}
+                                            :version version))))

--- a/src/keboola/facebook/api/request.clj
+++ b/src/keboola/facebook/api/request.clj
@@ -282,7 +282,9 @@
 
 ; https://developers.facebook.com/docs/pages/access-tokens
 ; https://graph.facebook.com/PAGE-ID?fields=access_token&access_token=USER-ACCESS-TOKEN
-(defn get-page-token-via-page-details [access-token page-id & {:keys [version]}]
-  (:access_token (apply concat (get-request access-token page-id
-                                            :query {:fields "access_token"}
-                                            :version version))))
+(defn get-page-token-via-page-details [access-token page-id]
+  (let [query-params {:fields "access_token" :access_token access-token}
+        url (str graph-api-url page-id)
+        response (client/GET url :query-params query-params :as :json)
+        body (:body response)]
+    (:access_token body)))

--- a/src/keboola/facebook/extractor/query.clj
+++ b/src/keboola/facebook/extractor/query.clj
@@ -26,7 +26,7 @@
 (defn retrieve-page-access-token [id token version]
   (let [accounts (swallow-exceptions (request/get-accounts token :version version))
         page-token-from-accounts-list (if (some? accounts) (:access_token (first (filter #(= id (:id %)) accounts))))
-        page-token-from-page-details (swallow-exceptions (request/get-page-token-via-page-details token id :version version))
+        page-token-from-page-details (swallow-exceptions (request/get-page-token-via-page-details token id))
         page-token (or page-token-from-accounts-list page-token-from-page-details)]
     (if (nil? page-token)
       (runtime/log-strings "Could not find page access token for" id ". Token from the configuration will be used instead.")

--- a/src/keboola/facebook/extractor/query.clj
+++ b/src/keboola/facebook/extractor/query.clj
@@ -25,7 +25,9 @@
 
 (defn retrieve-page-access-token [id token version]
   (let [accounts (swallow-exceptions (request/get-accounts token :version version))
-        page-token (if (some? accounts) (:access_token (first (filter #(= id (:id %)) accounts))))]
+        page-token-from-accounts-list (if (some? accounts) (:access_token (first (filter #(= id (:id %)) accounts))))
+        page-token-from-page-details (swallow-exceptions (request/get-page-token-via-page-details token id :version version))
+        page-token (or page-token-from-accounts-list page-token-from-page-details)]
     (if (nil? page-token)
       (runtime/log-strings "Could not find page access token for" id ". Token from the configuration will be used instead.")
       (runtime/log-strings "Using page access token to retrieve data for" id))


### PR DESCRIPTION
fixes https://keboola.atlassian.net/browse/ST-872
Tato uprava fixuje ex facebook, kde po bc change na fb api prestali vracat fb pages v requeste pre zoznam accountov (`me/accounts`) z ktoreho si fb ex nacital page access token.  To je reportovane ako bug ale fb sa moc nema k tomu aby to fixol vid https://developers.facebook.com/support/bugs/602264498523167/
Po novom to extractor okrem me/accounts skusa ako fallback aj cez `/PAGE-ID?fields=access_token` (https://developers.facebook.com/docs/pages/access-tokens), ako je poradene v tom bug reporte:
![image](https://github.com/keboola/ex-facebook-graph-api/assets/1412120/c4535030-76f0-4f23-8002-574bd44b8505)




### Test
- pustil som config so zbuldovanym tagom (kacurez-fix-page-token-retrieval-ST-872) a presiel https://connection.keboola.com/admin/projects/3244/jobs/1014312629
- ten isty config na latest tagu pada na chybe ze si nevie nacitat page token (sucasny stav) vid https://connection.keboola.com/admin/projects/3244/jobs/1014315099