### PR TITLE
support stories extraction

### DIFF
--- a/src/keboola/facebook/extractor/query.clj
+++ b/src/keboola/facebook/extractor/query.clj
@@ -84,6 +84,9 @@
 (defn query-path-ratings? [{:keys [path] :or {path ""}}]
   (string/includes? (or path "") "ratings"))
 
+(defn query-path-stories? [{:keys [path] :or {path ""}}]
+  (string/includes? (or path "") "stories"))
+
 (defn query-need-userinfo? [{:keys [fields path] :or {fields "" path ""}}]
   (or (some #(string/includes? (or fields "") %) ["likes" "from" "username"])
       (string/includes? (or path "") "likes")))
@@ -93,6 +96,7 @@
        (or (query-contains-insights? query)
            (query-path-ratings? query)
            (query-path-feed? query)
+           (query-path-stories? query)
            (query-path-posts? query)
            (query-need-userinfo? query))))
 


### PR DESCRIPTION
https://keboolaglobal.slack.com/archives/C055HSSLLKD/p1701167495010549
`stories` endpoint podla vsetkeho vyzaduje page access token. Tato uprava instruuje extractor aby ak v pripade ze je path query nastavena na `stories` tak request posle s page access token. Predpokladam ze to nikto iny neskusal, nie je mozne aby rovnaky endpoint bol podporovany cez user access token a obcas page access token, je to bud jedno alebo druhe.