### PR TITLE
increase max wait time for async ads insights to 10 hours

### DIFF
--- a/src/keboola/facebook/api/exponential_backoff.clj
+++ b/src/keboola/facebook/api/exponential_backoff.clj
@@ -3,14 +3,14 @@
 
 (def time-slot-ms 100)
 (def truncate 5)
-(def MAX_WAIT_TIME (* 1000 60 60 2))
+(def MAX_WAIT_TIME (* 1000 60 60 10))
 
 (defn with-exp-backoff [action!]
   (loop [c 0
          waited 0]
     (let [slot (* time-slot-ms (dec (Math/pow 2 c)))]
       (when (> waited MAX_WAIT_TIME)
-        (runtime/user-error "Polling timeout exceeded:" waited))
+        (runtime/user-error (str "Polling timeout exceeded:" waited)))
       (Thread/sleep slot)
       (when (not (action!))
         (recur (if (>= c truncate) c (inc c)) (+ waited slot))))))


### PR DESCRIPTION
This PR:
- fixes error throwing, it failed on wrong arguments
- increase max wait time for async insights jobs polling from 2 hours to 10 hours.

https://keboola.atlassian.net/browse/SUPPORT-6385?focusedCommentId=111591&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-111591