### PR TITLE
stop paging on empty response feature

### DIFF
--- a/src/keboola/facebook/api/request.clj
+++ b/src/keboola/facebook/api/request.clj
@@ -127,6 +127,7 @@
                                             (not (clojure.string/includes? next-url "until="))))
         stop-on-empty-response-valid (or (not stop-on-empty-response?)
                                          (not (-> response :data empty?)))]
+    (if (not stop-on-empty-response-valid) (log-strings "Found empty data response, stopping pagintaion."))
     (if (and time-base-pagination-valid stop-on-empty-response-valid)
       next-url)))
 
@@ -191,6 +192,7 @@
         sanitized-path (keyword (string/replace path #"/" "_"))]
 
     (log-strings "calling" full-url "with" preparsed-fields ids preparsed-since preparsed-until)
+    (if stop-on-empty-response? (log-strings "Stop on empty response is enabled."))
     (if (some? ids)
       (mapcat
        #(page-and-collect
@@ -235,6 +237,7 @@
         response (make-get-request url)
         response-body (:body response)]
     ;(println "response-body" response-body)
+    (if stop-on-empty-response? (log-strings "Stop on empty response is enabled."))
     (page-and-collect
      {:ex-account-id ad-account-id
       :parent-id ad-account-id

--- a/src/keboola/facebook/extractor/query.clj
+++ b/src/keboola/facebook/extractor/query.clj
@@ -103,7 +103,7 @@
 (defn run-async-insights-query [token out-dir name query version]
   (let [ids-str (:ids query)
         parameters (:parameters query)
-        run-query (fn [id] (request/async-insights-request token id parameters version))
+        run-query (fn [id] (request/async-insights-request token id parameters version query))
         ids-seq (s/split ids-str #",")
         all-merged-queries-rows (mapcat #(run-query %) ids-seq)
         all-rows (apply concat all-merged-queries-rows)]

--- a/test/keboola/facebook/api/request_test.clj
+++ b/test/keboola/facebook/api/request_test.clj
@@ -120,10 +120,10 @@
     (is (nil? (sut/get-next-page-url response true false)))
     (is (nil? (sut/get-next-page-url response false false))))
 
-  (let [response {:paging {:next "someurl"}} :data []]
+  (let [response {:paging {:next "someurl"} :data []}]
     (is (nil? (sut/get-next-page-url response false true))))
 
-  (let [response {:paging {:next "someurl"}} :data [{:some "data"}]]
+  (let [response {:paging {:next "someurl"} :data [{:some "data"}]}]
     (is (= "someurl" (sut/get-next-page-url response false true))))
 
   (let [response {:paging {:previous "https://graph.facebook.com/v16.0/17841401480255572/insights?access_token=XXX&pretty=0&metric=total_interactions&metric_type=total_value&period=day"

--- a/test/keboola/facebook/api/request_test.clj
+++ b/test/keboola/facebook/api/request_test.clj
@@ -113,17 +113,17 @@
 (deftest test-get-next-page-url
   (let [response {:paging {:previous "https://graph.facebook.com/v16.0/17841401480255572/insights?access_token=XXX&pretty=0&since=1672915646&until=1675248446&metric=total_interactions&metric_type=total_value&period=day"
                            :next "https://graph.facebook.com/v16.0/17841401480255572/insights?access_token=XXX&pretty=0&since=1677581248&until=1679914048&metric=total_interactions&metric_type=total_value&period=day"}}]
-    (is (nil? (sut/get-next-page-url response true)))
-    (is (= (sut/get-next-page-url response false) "https://graph.facebook.com/v16.0/17841401480255572/insights?access_token=XXX&pretty=0&since=1677581248&until=1679914048&metric=total_interactions&metric_type=total_value&period=day")))
+    (is (nil? (sut/get-next-page-url response true false)))
+    (is (= (sut/get-next-page-url response false false) "https://graph.facebook.com/v16.0/17841401480255572/insights?access_token=XXX&pretty=0&since=1677581248&until=1679914048&metric=total_interactions&metric_type=total_value&period=day")))
 
   (let [response {:paging {:previous "https://graph.facebook.com/v16.0/17841401480255572/insights?access_token=XXX&pretty=0&since=1672915646&until=1675248446&metric=total_interactions&metric_type=total_value&period=day"}}]
-    (is (nil? (sut/get-next-page-url response true)))
-    (is (nil? (sut/get-next-page-url response false))))
+    (is (nil? (sut/get-next-page-url response true false)))
+    (is (nil? (sut/get-next-page-url response false false))))
 
   (let [response {:paging {:previous "https://graph.facebook.com/v16.0/17841401480255572/insights?access_token=XXX&pretty=0&metric=total_interactions&metric_type=total_value&period=day"
                            :next "https://graph.facebook.com/v16.0/17841401480255572/insights?access_token=XXX&pretty=0&metric=total_interactions&metric_type=total_value&period=day"}}]
-    (is (= (sut/get-next-page-url response false) "https://graph.facebook.com/v16.0/17841401480255572/insights?access_token=XXX&pretty=0&metric=total_interactions&metric_type=total_value&period=day")))
+    (is (= (sut/get-next-page-url response false false) "https://graph.facebook.com/v16.0/17841401480255572/insights?access_token=XXX&pretty=0&metric=total_interactions&metric_type=total_value&period=day")))
 
   (let [response {:paging {:previous "https://graph.facebook.com/v16.0/17841401480255572/insights?access_token=XXX&pretty=0&metric=total_interactions&metric_type=total_value&period=day"
                            :next "https://graph.facebook.com/v16.0/17841401480255572/insights?access_token=XXX&pretty=0&metric=reach&metric_type=total_value&period=day"}}]
-    (is (= (sut/get-next-page-url response false) "https://graph.facebook.com/v16.0/17841401480255572/insights?access_token=XXX&pretty=0&metric=reach&metric_type=total_value&period=day"))))
+    (is (= (sut/get-next-page-url response false false) "https://graph.facebook.com/v16.0/17841401480255572/insights?access_token=XXX&pretty=0&metric=reach&metric_type=total_value&period=day"))))

--- a/test/keboola/facebook/api/request_test.clj
+++ b/test/keboola/facebook/api/request_test.clj
@@ -120,6 +120,12 @@
     (is (nil? (sut/get-next-page-url response true false)))
     (is (nil? (sut/get-next-page-url response false false))))
 
+  (let [response {:paging {:next "someurl"}} :data []]
+    (is (nil? (sut/get-next-page-url response false true))))
+
+  (let [response {:paging {:next "someurl"}} :data [{:some "data"}]]
+    (is (= "someurl" (sut/get-next-page-url response false true))))
+
   (let [response {:paging {:previous "https://graph.facebook.com/v16.0/17841401480255572/insights?access_token=XXX&pretty=0&metric=total_interactions&metric_type=total_value&period=day"
                            :next "https://graph.facebook.com/v16.0/17841401480255572/insights?access_token=XXX&pretty=0&metric=total_interactions&metric_type=total_value&period=day"}}]
     (is (= (sut/get-next-page-url response false false) "https://graph.facebook.com/v16.0/17841401480255572/insights?access_token=XXX&pretty=0&metric=total_interactions&metric_type=total_value&period=day")))


### PR DESCRIPTION
https://keboola.atlassian.net/browse/ST-2131
Stop pagination if response contains empty data but still returns next page url.
This only works if query has enabled `"stop-on-empty-response": true`. 
queries example with stop-on-empty-response enabled
```
    "queries": [
      {
        "id": 96947,
        "type": "async-insights-query",
        "name": "test",
        "run-by-id": false,
        "query": {
          "stop-on-empty-response": true,
          "parameters": "fields=ad_id,ad_name,impressions,reach,clicks,spend&level=ad&action_breakdowns=action_type&date_preset=last_month&time_increment=1",
          "ids": "",
          "limit": "25"
        }
      }
    ]
```